### PR TITLE
feat(binary_sensor): add Ready to Brew sensor with stabilisation delay

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,9 +11,9 @@ hass-gaggiuino/
 ├── custom_components/
 │   └── gaggiuino/
 │       ├── __init__.py          # Integration setup and platform registration
-│       ├── binary_sensor.py     # Binary sensor entities (availability, health, switches)
+│       ├── binary_sensor.py     # Binary sensor entities (availability, health, ready to brew, switches)
 │       ├── config_flow.py       # UI configuration flow
-│       ├── const.py             # Constants (DOMAIN, CONF_PROFILE)
+│       ├── const.py             # Constants (DOMAIN, ready-to-brew thresholds)
 │       ├── coordinator.py       # Data update coordinator - fetches and caches all API data
 │       ├── light.py             # LED light entity with RGB support
 │       ├── manifest.json        # Integration metadata and dependencies
@@ -104,6 +104,7 @@ class GaggiuinoEntity(CoordinatorEntity, PlatformEntity):
 ### Frozen Dataclasses
 
 The API models are frozen dataclasses. **Never try to modify their attributes directly.** Instead:
+
 - Create a new instance with updated values
 - Use `to_api_dict()` method to get a mutable dictionary for updates
 
@@ -127,6 +128,14 @@ The API models are frozen dataclasses. **Never try to modify their attributes di
 2. Add to `async_setup_entry()` function
 3. Add translation key to translations
 4. Add update method to coordinator if needed
+
+### Ready to Brew binary sensor
+
+The `ready_to_brew` binary sensor ([`binary_sensor.py`](custom_components/gaggiuino/binary_sensor.py)) is a dedicated entity (not in the `BINARY_SENSORS` tuple) because it tracks state over time:
+
+- **On** when `coordinator.gaggiuino_online` is true and `abs(temperature - targetTemperature) <= READY_TEMP_TOLERANCE_C` continuously for `READY_STABILISATION_SECONDS` (120s).
+- Uses `async_track_point_in_time` so the sensor turns on near the end of the hold window, not only on the 30s coordinator poll.
+- Tolerance and stabilisation duration are constants in [`const.py`](custom_components/gaggiuino/const.py); configurable delay via options flow is a possible follow-up.
 
 ### Updating Settings
 

--- a/custom_components/gaggiuino/binary_sensor.py
+++ b/custom_components/gaggiuino/binary_sensor.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
+from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Any
 
 from homeassistant.components.binary_sensor import (
@@ -12,10 +13,17 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntityDescription,
 )
 from homeassistant.const import EntityCategory
+from homeassistant.core import callback
+from homeassistant.helpers.event import async_track_point_in_time
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.util import dt as dt_util
 
 from .common import get_status_attr
-from .const import DOMAIN
+from .const import (
+    DOMAIN,
+    READY_STABILISATION_SECONDS,
+    READY_TEMP_TOLERANCE_C,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -76,6 +84,18 @@ BINARY_SENSORS = [
 ]
 
 
+def _temperature_in_range(coordinator: GaggiuinoDataUpdateCoordinator) -> bool:
+    """Return True if current temperature is within tolerance of target."""
+    temp = get_status_attr("temperature")(coordinator)
+    target = get_status_attr("targetTemperature")(coordinator)
+    if temp is None or target is None:
+        return False
+    try:
+        return abs(float(temp) - float(target)) <= READY_TEMP_TOLERANCE_C
+    except (TypeError, ValueError):
+        return False
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
@@ -84,10 +104,11 @@ async def async_setup_entry(
     """Set up the Gaggiuino sensors."""
     coordinator = hass.data[DOMAIN][config_entry.entry_id]
 
-    entities = [
+    entities: list[BinarySensorEntity] = [
         GaggiuinoBinarySensor(coordinator, description)
         for description in BINARY_SENSORS
     ]
+    entities.append(GaggiuinoReadyToBrewBinarySensor(coordinator))
 
     async_add_entities(entities)
 
@@ -118,3 +139,88 @@ class GaggiuinoBinarySensor(CoordinatorEntity, BinarySensorEntity):
     def is_on(self) -> bool:
         """Return true if the binary sensor is on."""
         return self.entity_description.value_fn(self.coordinator) is True
+
+
+class GaggiuinoReadyToBrewBinarySensor(CoordinatorEntity, BinarySensorEntity):
+    """Machine online and temperature stable for the stabilisation period."""
+
+    def __init__(self, coordinator: GaggiuinoDataUpdateCoordinator) -> None:
+        """Initialize the sensor."""
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{coordinator.entry.entry_id}_ready_to_brew"
+        self._attr_name = "Ready to Brew"
+        self._attr_has_entity_name = True
+        self._attr_translation_key = "ready_to_brew"
+        self._attr_icon = "mdi:coffee-maker-check"
+        self._attr_device_info = coordinator.device_info
+        self._attr_is_on = False
+
+        self._stable_since: datetime | None = None
+        self._unsub_ready: Callable[[], None] | None = None
+        self._hold_duration = timedelta(seconds=READY_STABILISATION_SECONDS)
+
+    async def async_added_to_hass(self) -> None:
+        """Run initial evaluation when entity is added."""
+        await super().async_added_to_hass()
+        self._evaluate()
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Cancel scheduled timer when entity is removed."""
+        self._reset_stabilisation()
+        await super().async_will_remove_from_hass()
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Re-evaluate when coordinator data changes."""
+        self._evaluate()
+        super()._handle_coordinator_update()
+
+    @callback
+    def _async_ready_fired(self, _now: datetime) -> None:
+        """Handle stabilisation timer completion."""
+        self._unsub_ready = None
+        self._evaluate()
+
+    def _reset_stabilisation(self) -> None:
+        """Clear stabilisation tracking and cancel pending timer."""
+        self._stable_since = None
+        if self._unsub_ready is not None:
+            self._unsub_ready()
+            self._unsub_ready = None
+
+    def _schedule_ready_at(self, when: datetime) -> None:
+        """Schedule a one-shot callback when stabilisation period ends."""
+        if self._unsub_ready is not None:
+            self._unsub_ready()
+        self._unsub_ready = async_track_point_in_time(
+            self.hass, self._async_ready_fired, when
+        )
+
+    def _set_off(self) -> bool:
+        """Turn sensor off and reset stabilisation. Returns True if state changed."""
+        self._reset_stabilisation()
+        if self._attr_is_on:
+            self._attr_is_on = False
+            return True
+        return False
+
+    def _evaluate(self) -> None:
+        """Update ready state from connectivity and temperature stability."""
+        changed = False
+
+        if not self.coordinator.gaggiuino_online or not _temperature_in_range(
+            self.coordinator
+        ):
+            changed = self._set_off()
+        else:
+            now = dt_util.utcnow()
+            if self._stable_since is None:
+                self._stable_since = now
+                self._schedule_ready_at(now + self._hold_duration)
+            elif (now - self._stable_since) >= self._hold_duration:
+                if not self._attr_is_on:
+                    self._attr_is_on = True
+                    changed = True
+
+        if changed:
+            self.async_write_ha_state()

--- a/custom_components/gaggiuino/const.py
+++ b/custom_components/gaggiuino/const.py
@@ -4,3 +4,6 @@ from typing import Final
 
 DOMAIN: Final = "gaggiuino"
 CONF_PROFILE: Final = "profile"
+
+READY_TEMP_TOLERANCE_C: Final = 0.8
+READY_STABILISATION_SECONDS: Final = 120

--- a/custom_components/gaggiuino/translations/en.json
+++ b/custom_components/gaggiuino/translations/en.json
@@ -1,108 +1,111 @@
 {
-    "config": {
-        "step": {
-            "user": {
-                "data": {
-                    "url": "Gaggiuino URL. Usually {default_url}"
-                }
-            }
-        },
-        "error": {
-            "cannot_connect": "Failed to connect",
-            "invalid_auth": "Invalid authentication",
-            "unknown": "Unexpected error"
-        },
-        "abort": {
-            "already_configured": "Device is already configured"
+  "config": {
+    "step": {
+      "user": {
+        "data": {
+          "url": "Gaggiuino URL. Usually {default_url}"
         }
+      }
     },
-    "entity": {
-        "sensor": {
-            "uptime": {
-                "name": "Uptime"
-            },
-            "profile_id": {
-                "name": "Profile ID"
-            },
-            "profile_name": {
-                "name": "Profile Name"
-            },
-            "latest_shot_id": {
-                "name": "Latest Shot ID"
-            },
-            "target_temperature": {
-                "name": "Target Temperature"
-            },
-            "temperature": {
-                "name": "Temperature"
-            },
-            "pressure": {
-                "name": "Pressure"
-            },
-            "water_level": {
-                "name": "Water Level"
-            },
-            "weight": {
-                "name": "Weight"
-            },
-            "core_version": {
-                "name": "Core Version"
-            },
-            "front_version": {
-                "name": "Frontend Version"
-            },
-            "static_version": {
-                "name": "Static Version"
-            },
-            "firmware_status": {
-                "name": "Firmware Status"
-            }
-        },
-        "binary_sensor": {
-            "availability": {
-                "name": "Availability"
-            },
-            "health": {
-                "name": "Health"
-            },
-            "brew_switch": {
-                "name": "Brew Switch"
-            },
-            "steam_switch": {
-                "name": "Steam Switch"
-            }
-        },
-        "select": {
-            "profile": {
-                "name": "Profile"
-            },
-            "release_channel": {
-                "name": "Release Channel"
-            }
-        },
-        "number": {
-            "steam_set_point": {
-                "name": "Steam"
-            }
-        },
-        "switch": {
-            "led_disco": {
-                "name": "LED Disco"
-            },
-            "force_predictive": {
-                "name": "Force Predictive Scales"
-            },
-            "hw_scales_enabled": {
-                "name": "Hardware Scales"
-            },
-            "bt_scales_enabled": {
-                "name": "Bluetooth Scales"
-            }
-        },
-        "light": {
-            "led": {
-                "name": "LED"
-            }
-        }
+    "error": {
+      "cannot_connect": "Failed to connect",
+      "invalid_auth": "Invalid authentication",
+      "unknown": "Unexpected error"
+    },
+    "abort": {
+      "already_configured": "Device is already configured"
     }
+  },
+  "entity": {
+    "sensor": {
+      "uptime": {
+        "name": "Uptime"
+      },
+      "profile_id": {
+        "name": "Profile ID"
+      },
+      "profile_name": {
+        "name": "Profile Name"
+      },
+      "latest_shot_id": {
+        "name": "Latest Shot ID"
+      },
+      "target_temperature": {
+        "name": "Target Temperature"
+      },
+      "temperature": {
+        "name": "Temperature"
+      },
+      "pressure": {
+        "name": "Pressure"
+      },
+      "water_level": {
+        "name": "Water Level"
+      },
+      "weight": {
+        "name": "Weight"
+      },
+      "core_version": {
+        "name": "Core Version"
+      },
+      "front_version": {
+        "name": "Frontend Version"
+      },
+      "static_version": {
+        "name": "Static Version"
+      },
+      "firmware_status": {
+        "name": "Firmware Status"
+      }
+    },
+    "binary_sensor": {
+      "availability": {
+        "name": "Availability"
+      },
+      "health": {
+        "name": "Health"
+      },
+      "brew_switch": {
+        "name": "Brew Switch"
+      },
+      "steam_switch": {
+        "name": "Steam Switch"
+      },
+      "ready_to_brew": {
+        "name": "Ready to Brew"
+      }
+    },
+    "select": {
+      "profile": {
+        "name": "Profile"
+      },
+      "release_channel": {
+        "name": "Release Channel"
+      }
+    },
+    "number": {
+      "steam_set_point": {
+        "name": "Steam"
+      }
+    },
+    "switch": {
+      "led_disco": {
+        "name": "LED Disco"
+      },
+      "force_predictive": {
+        "name": "Force Predictive Scales"
+      },
+      "hw_scales_enabled": {
+        "name": "Hardware Scales"
+      },
+      "bt_scales_enabled": {
+        "name": "Bluetooth Scales"
+      }
+    },
+    "light": {
+      "led": {
+        "name": "LED"
+      }
+    }
+  }
 }


### PR DESCRIPTION
# Summary
Adds a native Ready to Brew binary sensor so users can trigger heat-up automations, badges, and notifications without template sensors.

The entity turns on when:

- The machine is available (`gaggiuino_online`, same basis as the connectivity binary sensor), and
- `abs(temperature − targetTemperature) ≤ 0.8 °C` for `120` seconds continuously.

A one-shot `async_track_point_in_time` timer flips the state at the end of the hold window instead of waiting only for the 30s coordinator poll. Leaving the band or going offline resets the timer and turns the sensor off.

Constants live in const.py (`READY_TEMP_TOLERANCE_C`, `READY_STABILISATION_SECONDS`).

## Tested

- [x] Sensor `binary_sensor.gaggiuino_ready_to_brew` appears on the device
- [x] While offline or out of tolerance: sensor is `OFF`
- [x] Heat to target: sensor stays off for ~2 minutes in band, then on
- [x] Disconnect device / API failure: sensor off, timer cleared.
- [x] Switch profile while heating: behaviour follows updated targetTemperature from status

## Potential follow-ups 
- Configurable stabilisation delay / tolerance (options flow or config entity)
- Simplify `gaggiuino_heated_up.yaml` to use this sensor instead of template triggers